### PR TITLE
Fix bookmark thumbnail images in Safari

### DIFF
--- a/assets/css/ghost/content.css
+++ b/assets/css/ghost/content.css
@@ -231,6 +231,7 @@
     justify-content: flex-start;
     align-items: flex-start;
     padding: 20px;
+    order: 1;
 }
 
 .kg-bookmark-title {

--- a/assets/css/ghost/content.css
+++ b/assets/css/ghost/content.css
@@ -212,6 +212,7 @@
 .kg-bookmark-container,
 .kg-bookmark-container:hover {
     display: flex;
+    min-height: 148px;
     flex-wrap: wrap;
     flex-direction: row-reverse;
     color: currentColor;
@@ -225,9 +226,11 @@
 
 .kg-bookmark-content {
     flex-basis: 0;
-    flex-grow: 999;
+    flex-grow: 1;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-start;
     padding: 20px;
-    order: 1;
 }
 
 .kg-bookmark-title {
@@ -277,16 +280,18 @@
 }
 
 .kg-bookmark-thumbnail {
-    display: flex;
-    flex-basis: 24rem;
-    flex-grow: 1;
-    justify-content: flex-end;
+    position: relative;
+    min-width: 33%;
+    max-height: 100%;
 }
 
 .kg-bookmark-thumbnail img {
-    max-width: 100%;
-    height: auto;
-    vertical-align: bottom;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: 0 3px 3px 0;
     object-fit: cover;
 }
 
@@ -301,6 +306,21 @@
     margin: 0 .5em;
 }
 
+@media (max-width: 500px) {
+    .post-full-content .kg-bookmark-container {
+        flex-direction: column;
+    }
+
+    .kg-bookmark-thumbnail {
+        order: 1;
+        min-height: 160px;
+        width: 100%;
+    }
+
+    .kg-bookmark-content {
+        order: 2;
+    }
+}
 
 /* Card captions
 /* ---------------------------------------------------------- */


### PR DESCRIPTION
Closes #40 (Bookmark thumbnail images are very tall in Safari)

This PR fixes this issue with the same code as Casper, not using flexbox to avoid the incompatibility.

I've only brought in the non-styling code to keep Starter unstyled.