### PR TITLE
Adopt the shared Renovate theme preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,6 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "@tryghost:theme"
-  ],
-  "schedule": ["after 12am and before 4am"],
-  "timezone": "UTC",
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true
-    }
+    "local>TryGhost/renovate-config:theme.json5"
   ]
 }


### PR DESCRIPTION
Adopts the shared Renovate preset `local>TryGhost/renovate-config:theme.json5` so dependency updates are kept current automatically.

Part of the `cleanrepos rollout renovate --type theme` batch. Review the `renovate.json` change and merge when ready.
