### PR TITLE
Fixed broken pnpm/action-setup pin in workflows

### DIFF
--- a/.github/workflows/deploy-theme.yml
+++ b/.github/workflows/deploy-theme.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:


### PR DESCRIPTION
## Summary

- Replaced the `pnpm/action-setup` pin `ac6db6d3c1f721f886538a378a2d73e85697340a` with `0e279bb959325dab635dd2c09392533439d90093` in `.github/workflows/test.yml` and `.github/workflows/deploy-theme.yml`.
- The old digest no longer resolves as a commit upstream (GitHub returns HTTP 422), so any job using it fails at action resolution. Root cause: it is the annotated **tag object** SHA of the `v6` tag, not a commit SHA — GitHub Actions can only resolve commit SHAs. The replacement is the verified commit the current `v6`/`v6.0.8` tag points to.
- No version comment appended, matching this repo's convention of bare digest pins.
- Zip script audited per the related CodeRabbit findings in TryGhost/Themes#529: the `bestzip` script uses explicit include globs (`assets/* partials/* members/* *.hbs package.json`) that cannot match `pnpm-workspace.yaml`, so no zip change is needed.

## Verification

- `gh api repos/pnpm/action-setup/commits/ac6db6d...` → HTTP 422 (confirmed broken); `.../commits/0e279bb...` resolves; `git/tags/ac6db6d...` dereferences to commit `0e279bb...` (`v6`).
- `pnpm install --frozen-lockfile` → up to date.
- `pnpm zip` then `unzip -l ghost-starter-theme.zip | grep -i 'pnpm\|workspace'` → no matches; zip contains only theme assets, templates, and `package.json` (47 files).
- `pnpm test:ci` (gscan fatal/verbose) → no fatal compatibility issues.

Ref: TryGhost/Themes#529