### PR TITLE
Renamed CI gate check to org-standard "Required checks pass"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
 
       - run: pnpm test
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Requiring individual or legacy check names in branch protection couples the ruleset to the CI matrix: rename a job (or change a matrix leg) and the required check silently no longer exists, blocking every PR. The org is standardizing every repo on one stable aggregator check named exactly **Required checks pass**, so branch protection has a single target that never changes.

This renames the existing `All tests pass` gate job in `.github/workflows/test.yml` to the new convention:

- job id: `required-checks-pass`, `name: Required checks pass`
- `if: always()` and `needs: [test]` unchanged — coverage is identical to the old gate (the workflow's only other job)
- top-level `permissions: contents: read` was already present

The branch ruleset is being updated in the same pass to require `Required checks pass` instead of `All tests pass`, so this PR must go green on the new gate before merge.